### PR TITLE
feat(course): add update course details & soft delete

### DIFF
--- a/src/course/course.controller.ts
+++ b/src/course/course.controller.ts
@@ -1,12 +1,13 @@
-import { Body, Controller, Get, ParseIntPipe, Post, Query, Req, Res } from '@nestjs/common';
+import { Body, Controller, Delete, Get, ParseIntPipe, Post, Put, Query, Req, Res } from '@nestjs/common';
 import { CoursesService } from './course.service';
 import { CreateCourseRequest } from './request/create-course.request';
 import { Response } from 'express';
 import { isValidId } from 'src/validator/is-valid-id.decorator';
 import { cp } from 'fs';
 import { FindCoursesRequest } from './request/find-courses.request';
+import { UpdateCourseRequest } from './request/update-course.request';
 
-@Controller('courses')
+@Controller('course')
 export class CoursesController {
     constructor(
         private readonly coursesService: CoursesService,
@@ -38,6 +39,22 @@ export class CoursesController {
         return res.status(200).json({
             data: course,
         });
+    }
+
+    @Put(':id')
+    async updateCourse(@isValidId() id: number, @Body() body: UpdateCourseRequest, @Res() res: Response) {
+        const course = await this.coursesService.updateCourse(id, body);
+
+        return res.status(200).json({
+            data: course,
+        });
+    }
+
+    @Delete(':id')
+    async softDeleteCourse(@isValidId() id: number, @Res() res: Response) {
+        await this.coursesService.softDeleteCourse(id);
+
+        return res.status(204).send();
     }
 
 }

--- a/src/course/course.entity.ts
+++ b/src/course/course.entity.ts
@@ -1,4 +1,4 @@
-import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+import { Column, CreateDateColumn, DeleteDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
 import { DifficultyLevel } from "./enum/level.enum";
 
 @Entity('courses')
@@ -23,5 +23,8 @@ export class CourseEntity {
 
     @UpdateDateColumn()
     updatedAt: Date;
+
+    @DeleteDateColumn({ nullable: true })
+    deletedAt: Date | null;
 
 }

--- a/src/course/request/create-course.request.ts
+++ b/src/course/request/create-course.request.ts
@@ -1,4 +1,4 @@
-import { IsEnum, IsNotEmpty, IsNumber, IsString } from "class-validator";
+import { IsEnum, IsNotEmpty, IsNumber, IsString, Min } from "class-validator";
 import { IsNotNullOrUndefined } from "src/validator/Is-not-null-or-undefined.decorator";
 import { DifficultyLevel } from "../enum/level.enum";
 
@@ -17,5 +17,6 @@ export class CreateCourseRequest {
 
     @IsNotNullOrUndefined()
     @IsNumber()
+    @Min(0)
     price: number;
 }

--- a/src/course/request/update-course.request.ts
+++ b/src/course/request/update-course.request.ts
@@ -1,0 +1,21 @@
+import { IsEnum, IsNumber, IsOptional, IsString, Min } from "class-validator";
+import { DifficultyLevel } from "../enum/level.enum";
+
+export class UpdateCourseRequest {
+    @IsOptional()
+    @IsString()
+    title?: string;
+
+    @IsOptional()
+    @IsString()
+    description?: string;
+
+    @IsOptional()
+    @IsEnum(DifficultyLevel)
+    difficultyLevel?: DifficultyLevel;
+
+    @IsOptional()
+    @IsNumber()
+    @Min(0)
+    price?: number;
+}


### PR DESCRIPTION
### What does this PR do?
1. **Update Course**: Allows updating course details (title, description, difficultyLevel, price) via a PUT endpoint.
2. **Soft Delete**: Implements soft deletion for courses by adding a `deletedAt` field and marking it instead of removing records.

### Why is this needed?
- **Update Course**: Users need to modify course info after creation (e.g., editing description).
- **Soft Delete**: We want to retain deleted course data for auditing/recovery purposes instead of permanent deletion.

### How did you implement it?
- Added `UpdateCourseRequest` custom request class with required fields and validation rules.
- Updated `CourseEntity` with a `deletedAt: Date | null` column for soft delete.
- Added `softDeleteCourse` in `CourseService` using `update` to set `deletedAt`.
- Added `updateCourse` in `CourseService` to update course details.
- Adjusted `CourseController` with `@Put(':id')` and `@Delete(':id')` endpoints.
- Ensured all queries (e.g., `findCourseById`) filter out soft-deleted courses (`deletedAt: null`).


### How to test it?
1. **Update Course**:
   - Send a PUT request to `/course/:id` with updated course details.
   - Ensure the course details are updated in the database.
   - Ensure validation rules are enforced (e.g., price must be a non-negative number).

2. **Soft Delete**:
    - Send a DELETE request to `/course/:id`.
    - Ensure the course is soft-deleted (i.e., `deletedAt` is set).
    - Ensure the course is not returned in the list of active courses.
