### PR TITLE
feat(section): add section feature to manage course sections

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { LoggerMiddleware } from './middleware/logger.middleware';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 import { CoursesModule } from './course/course.module';
+import { SectionModule } from './section/section.module';
 
 @Module({
   imports: [
@@ -30,7 +31,7 @@ import { CoursesModule } from './course/course.module';
       }),
       inject: [ConfigService],
     })
-    ,AuthModule, UserModule, CoursesModule],
+    ,AuthModule, UserModule, CoursesModule, SectionModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/course/course.entity.ts
+++ b/src/course/course.entity.ts
@@ -1,5 +1,6 @@
-import { Column, CreateDateColumn, DeleteDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+import { Column, CreateDateColumn, DeleteDateColumn, Entity, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
 import { DifficultyLevel } from "./enum/level.enum";
+import { SectionEntity } from "src/section/section.entity";
 
 @Entity('courses')
 export class CourseEntity {
@@ -27,4 +28,6 @@ export class CourseEntity {
     @DeleteDateColumn({ nullable: true })
     deletedAt: Date | null;
 
+    @OneToMany(() => SectionEntity, (section) => section.course)
+    sections: SectionEntity[];
 }

--- a/src/course/course.module.ts
+++ b/src/course/course.module.ts
@@ -7,6 +7,7 @@ import { CourseEntity } from './course.entity';
 @Module({
   imports: [TypeOrmModule.forFeature([CourseEntity])],
   providers: [CoursesService],
-  controllers: [CoursesController]
+  controllers: [CoursesController],
+  exports: [CoursesService],
 })
 export class CoursesModule {}

--- a/src/section/exception/section-already-exists.exception.ts
+++ b/src/section/exception/section-already-exists.exception.ts
@@ -1,0 +1,7 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class SectionAlreadyExistsException extends HttpException {
+    constructor(courseId: number, order: number) {
+        super(`Section with order '${order}' already exists in course '${courseId}'`, HttpStatus.CONFLICT);
+    }
+}

--- a/src/section/exception/section-not-found.exception.ts
+++ b/src/section/exception/section-not-found.exception.ts
@@ -1,0 +1,7 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class SectionNotFoundException extends HttpException {
+    constructor(sectionId: number) {
+        super(`Section with ID '${sectionId}' not found`, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/section/request/create-section.request.ts
+++ b/src/section/request/create-section.request.ts
@@ -1,0 +1,12 @@
+import { IsNumber, IsPositive, IsString } from "class-validator";
+import { IsNotNullOrUndefined } from "src/validator/Is-not-null-or-undefined.decorator";
+
+export class CreateSectionRequest {
+    @IsNotNullOrUndefined()
+    @IsString()
+    title: string;
+
+    @IsNumber()
+    @IsPositive()
+    order: number;
+}

--- a/src/section/response/section.response.ts
+++ b/src/section/response/section.response.ts
@@ -1,0 +1,18 @@
+export class SectionResponse {
+    id: number;
+    title: string;
+    order: number;
+    courseId: number;
+    createdAt: Date;
+    updatedAt: Date;
+
+    constructor(section: any) {
+        this.id = section.id;
+        this.title = section.title;
+        this.order = section.order;
+        this.courseId = section.course.id;
+        this.createdAt = section.createdAt;
+        this.updatedAt = section.updatedAt;
+    }
+
+}

--- a/src/section/section.controller.spec.ts
+++ b/src/section/section.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SectionController } from './section.controller';
+
+describe('SectionController', () => {
+  let controller: SectionController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SectionController],
+    }).compile();
+
+    controller = module.get<SectionController>(SectionController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/section/section.controller.ts
+++ b/src/section/section.controller.ts
@@ -1,0 +1,56 @@
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, Put, Res } from '@nestjs/common';
+import { SectionService } from './section.service';
+import { CreateSectionRequest } from './request/create-section.request';
+import { Response } from 'express';
+import { isValidCourseId } from './validator/is-valid-course-id.decorator';
+import { isValidOrder } from './validator/is-valid-order.decorator';
+
+@Controller('course/:courseId/section')
+export class SectionController {
+    constructor(
+        private readonly sectionService: SectionService,
+    ) {}
+
+    @Post()
+    async createSection(@isValidCourseId() courseId: number, @Body() section: CreateSectionRequest, @Res() res :Response) {
+        const newSection = await this.sectionService.createSection(section, courseId);
+
+        return res.status(201).json({
+            data: newSection,
+        });
+    }
+
+    @Get(':order')
+    async getSectionByOrderForCourse(@isValidOrder() order: number, @isValidCourseId() courseId: number, @Res() res: Response) {
+        const section = await this.sectionService.getSectionByOrderForCourse(order, courseId);
+
+        return res.status(200).json({
+            data: section,
+        });
+    }
+
+    @Get()
+    async getSectionsByCourseId(@isValidCourseId() courseId: number, @Res() res: Response) {
+        const sections = await this.sectionService.getSectionsByCourseId(courseId);
+
+        return res.status(200).json({
+            data: sections,
+        });
+    }
+
+    @Put(':order')
+    async updateSection(@isValidOrder() order: number, @isValidCourseId() courseId: number, @Body() section: CreateSectionRequest, @Res() res: Response) {
+        const updatedSection = await this.sectionService.updateSection(courseId, order, section);
+
+        return res.status(200).json({
+            data: updatedSection,
+        });
+    }
+
+    @Delete(':order')
+    async softDeleteSection(@isValidOrder() order: number, @isValidCourseId() courseId: number, @Res() res: Response) {
+        await this.sectionService.softDeleteSection(order, courseId);
+
+        return res.status(204).send();
+    }
+}

--- a/src/section/section.entity.ts
+++ b/src/section/section.entity.ts
@@ -1,0 +1,26 @@
+import { CourseEntity } from "src/course/course.entity";
+import { Column, CreateDateColumn, DeleteDateColumn, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+
+@Entity('section')
+export class SectionEntity {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+    @Column()
+    order: number;
+
+    @ManyToOne(() => CourseEntity, (course) => course.sections, { onDelete: 'CASCADE' })
+    course: CourseEntity;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+
+    @DeleteDateColumn({ nullable: true })
+    deletedAt: Date | null;
+}

--- a/src/section/section.module.ts
+++ b/src/section/section.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SectionEntity } from './section.entity';
+import { SectionController } from './section.controller';
+import { SectionService } from './section.service';
+import { CoursesModule } from 'src/course/course.module';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([SectionEntity]), CoursesModule],
+    controllers: [SectionController],
+    providers: [SectionService],
+})
+export class SectionModule {}

--- a/src/section/section.service.spec.ts
+++ b/src/section/section.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SectionService } from './section.service';
+
+describe('SectionService', () => {
+  let service: SectionService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SectionService],
+    }).compile();
+
+    service = module.get<SectionService>(SectionService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/section/section.service.ts
+++ b/src/section/section.service.ts
@@ -1,0 +1,97 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { SectionEntity } from './section.entity';
+import { Repository } from 'typeorm';
+import { CreateSectionRequest } from './request/create-section.request';
+import { CoursesService } from 'src/course/course.service';
+import { SectionAlreadyExistsException } from './exception/section-already-exists.exception';
+import { SectionResponse } from './response/section.response';
+import { SectionNotFoundException } from './exception/section-not-found.exception';
+
+@Injectable()
+export class SectionService {
+    constructor(
+        @InjectRepository(SectionEntity)
+        private readonly sectionRepository: Repository<SectionEntity>,
+        private readonly courseService: CoursesService,
+    ) { }
+
+    async checkSectionDoesNotExist(order: number, courseId: number): Promise<void> {
+        const section = await this.sectionRepository.findOne({ where: { order, course: { id: courseId } } });
+
+        if (section) {
+            throw new SectionAlreadyExistsException(courseId, order);
+        }
+    }
+
+    async createSection(section: CreateSectionRequest, courseId: number): Promise<SectionResponse> {
+        const course = await this.courseService.findCourseEntityById(courseId);
+
+        await this.checkSectionDoesNotExist(section.order, courseId);
+
+        const newSection = this.sectionRepository.create({ ...section, course });
+
+        const savedSection = await this.sectionRepository.save(newSection);
+
+        return new SectionResponse(savedSection);
+    }
+
+    async getSectionByOrderForCourse(order: number, courseId: number): Promise<SectionResponse> {
+        const section = await this.sectionRepository.findOne({ where: { order, course: { id: courseId }, deletedAt: null }, relations: ['course'] });
+
+        if (!section) {
+            throw new SectionNotFoundException(order);
+        }
+
+        return new SectionResponse(section);
+    }
+
+    async findSectionById(id: number): Promise<SectionResponse> {
+        const section = await this.sectionRepository.findOne({ where: { id, deletedAt: null }, relations: ['course'] });
+
+        if (!section) {
+            throw new SectionNotFoundException(id);
+        }
+
+        return new SectionResponse(section);
+    }
+
+    async getSectionsByCourseId(courseId: number): Promise<SectionResponse[]> {
+        const sections = await this.sectionRepository.find({ where: { course: { id: courseId }, deletedAt: null }, relations: ['course'] });
+
+        return sections.map(section => new SectionResponse(section));
+    }
+
+    async getSectionEntityById(id: number): Promise<SectionEntity> {
+        const section = await this.sectionRepository.findOne({ where: { id, deletedAt: null }, relations: ['course'] });
+
+        if (!section) {
+            throw new SectionNotFoundException(id);
+        }
+
+        return section;
+    }
+
+    async updateSection(courseId:number, order: number, updateData: CreateSectionRequest): Promise<SectionResponse> {
+        const section = await this.getSectionByOrderForCourse(order, courseId);
+
+        await this.sectionRepository.save(
+            Object.assign(section, {
+                title: updateData.title ?? section.title,
+                order: updateData.order ?? section.order,
+            }
+            )
+        );
+
+        const updatedSection = await this.getSectionEntityById(section.id);
+
+        return new SectionResponse(updatedSection);
+    }
+
+    async softDeleteSection(order: number, courseId: number): Promise<void> {
+        const section = await this.getSectionByOrderForCourse(order, courseId);
+
+        await this.sectionRepository.update(section.id, { deletedAt: new Date() });
+    }
+
+}

--- a/src/section/validator/is-valid-course-id.decorator.ts
+++ b/src/section/validator/is-valid-course-id.decorator.ts
@@ -1,0 +1,14 @@
+import { BadRequestException, createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const isValidCourseId = createParamDecorator(
+    (data: unknown, ctx: ExecutionContext) => {
+        const request = ctx.switchToHttp().getRequest();
+        const courseId = Number(request.params.courseId);
+
+        if (isNaN(courseId) || !Number.isInteger(courseId) || courseId <= 0) {
+            throw new BadRequestException('Course ID must be a positive integer');
+        }
+
+        return courseId;
+    },
+); 

--- a/src/section/validator/is-valid-order.decorator.ts
+++ b/src/section/validator/is-valid-order.decorator.ts
@@ -1,0 +1,14 @@
+import { BadRequestException, createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const isValidOrder = createParamDecorator(
+    (data: unknown, ctx: ExecutionContext) => {
+        const request = ctx.switchToHttp().getRequest();
+        const order = Number(request.params.order);
+
+        if (isNaN(order) || !Number.isInteger(order) || order <= 0) {
+            throw new BadRequestException('Order must be a positive integer');
+        }
+
+        return order;
+    },
+); 


### PR DESCRIPTION
## What does this PR do?
- **Section Module Integration**: Introduces a new Section module to manage sections within courses, fully integrated with the existing Course module.
- **CRUD Operations for Sections**: Adds functionality to create, retrieve, update, and soft-delete sections associated with a specific course.
- **Custom Validation**: Implements custom validators and exceptions for section-related operations (e.g., ensuring unique order within a course).

## Why is this needed?
- **Section Management**: Users need to organize course content into sections (e.g., lectures or chapters) to improve course structure and navigation.
- **Data Integrity**: Custom validators ensure valid course IDs and section orders, preventing duplicates or invalid data.
- **Flexibility**: Allows adding, updating, and removing sections without affecting the course entity, while retaining deleted sections for auditing purposes.

## How did you implement it?
- **Module Integration**:
  - Updated `src/app.module.ts` by adding `SectionModule` to the `imports` array to integrate it into the application.
- **Entity Relationships**:
  - Modified `src/course/course.entity.ts` to include a `@OneToMany` relationship with `SectionEntity`.
  - Created `src/section/section.entity.ts` with a `@ManyToOne` relationship to `CourseEntity`, defining section structure (id, title, order, etc.).
- **Controller and Service**:
  - Added `src/section/section.controller.ts` with endpoints for creating (`POST`), retrieving (`GET`), updating (`PUT`), and soft-deleting (`DELETE`) sections.
  - Implemented `src/section/section.service.ts` with business logic for section management, including database operations and validation.
- **Custom Exceptions and Validators**:
  - Created `src/section/exception/section-already-exists.exception.ts` to handle duplicate section orders within a course.
  - Added `src/section/validator/is-valid-course-id.decorator.ts` to validate `courseId` param as a positive integer.
  - Added `src/section/validator/is-valid-order.decorator.ts` to validate `order` param as a positive integer.
- **Soft Delete**:
  - Ensured `SectionEntity` includes a `deletedAt: Date | null` column for soft deletion.
  - Updated queries (e.g., `findOne`, `find`) to filter out soft-deleted sections (`deletedAt: null`).
