### PR TITLE
feat(section): add soft delete operation

### DIFF
--- a/src/section/section.controller.ts
+++ b/src/section/section.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Put, Query, Res } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Post, Put, Query, Res } from '@nestjs/common';
 import { SectionService } from './section.service';
 import { CreateSectionRequest } from './request/create-section.request';
 import { Response } from 'express';
@@ -48,5 +48,12 @@ export class SectionController {
         return res.status(200).json({
             data: updatedSection,
         });
+    }
+
+    @Delete(':id')
+    async softDeleteSection(@isValidId() id: number, @Res() res: Response) {
+        await this.sectionService.softDeleteSection(id);
+
+        return res.status(204).send();
     }
 }


### PR DESCRIPTION
## What does this PR do?
- **Soft Delete Functionality**: Adds the ability to soft delete sections within a course, marking them as deleted instead of removing them permanently.
- **Section Reordering**: Ensures remaining sections are reordered after a soft delete to maintain consistent `order` values.
- **Controller and Service Enhancements**: Extends the `section` module with a new DELETE endpoint and logic to handle soft deletion efficiently.

## Why is this needed?
- **Section Management**: Allows users to "delete" sections without losing data, enabling recovery if needed.
- **Data Integrity**: Reordering keeps the `order` sequence intact within a course after a section is soft deleted.
- **Improved Usability**: Provides a clear API endpoint for soft deleting sections, enhancing flexibility and control over course content.

## How did you implement it?

### Controller Updates:
- Modified `src/section/section.controller.ts`:
  - Added a `@Delete(':id')` endpoint (`DELETE /section/:id`) to handle soft deletion requests and return a success response with `204 No Content`.

### Service Updates:
- Updated `src/section/section.service.ts`:
  - Implemented `softDeleteSection` method to mark a section as deleted (e.g., setting `deletedAt`) and reorder remaining sections using `QueryBuilder` for efficient updates.