### PR TITLE
feat(course): handle course cover with dropbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "pg": "^8.13.3",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
+        "slugify": "^1.6.6",
         "swagger-ui-express": "^5.0.1",
         "typeorm": "^0.3.21",
         "typeorm-naming-strategies": "^4.1.0"
@@ -9076,6 +9077,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "pg": "^8.13.3",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
+    "slugify": "^1.6.6",
     "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.21",
     "typeorm-naming-strategies": "^4.1.0"

--- a/src/common/pipes/optional-image-validation.pipe.ts
+++ b/src/common/pipes/optional-image-validation.pipe.ts
@@ -1,0 +1,20 @@
+import { ArgumentMetadata, FileTypeValidator, Injectable, MaxFileSizeValidator, ParseFilePipe, PipeTransform } from '@nestjs/common';
+
+@Injectable()
+export class OptionalImageFilePipe implements PipeTransform {
+    private readonly validators = [ 
+        new MaxFileSizeValidator({ maxSize: 5 * 1024 * 1024 }),
+        new FileTypeValidator({ fileType: /image\/(jpg|jpeg|png|webp)/ }),
+    ];
+
+    async transform(file: Express.Multer.File | undefined, metadata: ArgumentMetadata): Promise<Express.Multer.File | undefined> {
+        if (!file) return file; // undefined
+
+        const pipe = new ParseFilePipe({
+            fileIsRequired: false,
+            validators: this.validators,
+        });
+
+        return pipe.transform(file);
+    }
+}

--- a/src/common/pipes/required-image-validation.pipe.ts
+++ b/src/common/pipes/required-image-validation.pipe.ts
@@ -1,0 +1,18 @@
+import { ArgumentMetadata, FileTypeValidator, Injectable, MaxFileSizeValidator, ParseFilePipe, PipeTransform } from '@nestjs/common';
+
+@Injectable()
+export class RequiredImagePipe implements PipeTransform {
+    private readonly validators = [
+        new MaxFileSizeValidator({ maxSize: 5 * 1024 * 1024 }),
+        new FileTypeValidator({ fileType: /image\/(jpg|jpeg|png|webp)/ }),
+    ];
+
+    async transform(file: Express.Multer.File | undefined, metadata: ArgumentMetadata): Promise<Express.Multer.File> {
+        const pipe = new ParseFilePipe({
+            fileIsRequired: true,
+            validators: this.validators,
+        });
+
+        return pipe.transform(file);
+    }
+}

--- a/src/course/course.controller.ts
+++ b/src/course/course.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, ParseIntPipe, Post, Put, Query, Req, Res } from '@nestjs/common';
+import { Body, Controller, Delete, Get, ParseIntPipe, Post, Put, Query, Req, Res, UploadedFile, UseInterceptors } from '@nestjs/common';
 import { CoursesService } from './course.service';
 import { CreateCourseRequest } from './request/create-course.request';
 import { Response } from 'express';
@@ -6,6 +6,9 @@ import { isValidId } from 'src/validator/is-valid-id.decorator';
 import { cp } from 'fs';
 import { FindCoursesRequest } from './request/find-courses.request';
 import { UpdateCourseRequest } from './request/update-course.request';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { OptionalImageFilePipe } from 'src/common/pipes/optional-image-validation.pipe';
+import { RequiredImagePipe } from 'src/common/pipes/required-image-validation.pipe';
 
 @Controller('course')
 export class CoursesController {
@@ -14,8 +17,9 @@ export class CoursesController {
     ) {}
 
     @Post()
-    async createCourse(@Body() body: CreateCourseRequest, @Res() res: Response) {
-        const course = await this.coursesService.createCourse(body);
+    @UseInterceptors(FileInterceptor('cover'))
+    async createCourse(@Body() body: CreateCourseRequest, @UploadedFile(RequiredImagePipe) file: Express.Multer.File, @Res() res: Response) {
+        const course = await this.coursesService.createCourse(body, file);
 
         return res.status(201).json({
             data: course,
@@ -42,8 +46,9 @@ export class CoursesController {
     }
 
     @Put(':id')
-    async updateCourse(@isValidId() id: number, @Body() body: UpdateCourseRequest, @Res() res: Response) {
-        const course = await this.coursesService.updateCourse(id, body);
+    @UseInterceptors(FileInterceptor('cover'))
+    async updateCourse(@isValidId() id: number, @UploadedFile(OptionalImageFilePipe) cover: Express.Multer.File | undefined, @Body() body: UpdateCourseRequest, @Res() res: Response) {
+        const course = await this.coursesService.updateCourse(id, body, cover);
 
         return res.status(200).json({
             data: course,

--- a/src/course/course.entity.ts
+++ b/src/course/course.entity.ts
@@ -11,6 +11,9 @@ export class CourseEntity {
     title: string;
 
     @Column()
+    uniqueTitle: string;
+
+    @Column()
     description: string;
 
     @Column({ type: "decimal"})
@@ -18,6 +21,9 @@ export class CourseEntity {
 
     @Column({ type: "enum", enum: DifficultyLevel })
     difficultyLevel: DifficultyLevel;
+
+    @Column()
+    coverUrl: string;
 
     @CreateDateColumn()
     createdAt: Date;

--- a/src/course/course.module.ts
+++ b/src/course/course.module.ts
@@ -3,9 +3,10 @@ import { CoursesService } from './course.service';
 import { CoursesController } from './course.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CourseEntity } from './course.entity';
+import { DropboxModule } from 'src/dropbox/dropbox.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([CourseEntity])],
+  imports: [TypeOrmModule.forFeature([CourseEntity]), DropboxModule],
   providers: [CoursesService],
   controllers: [CoursesController],
   exports: [CoursesService],

--- a/src/course/response/course.response.ts
+++ b/src/course/response/course.response.ts
@@ -6,6 +6,8 @@ export class CourseResponse {
     price: number;
     createdAt: Date;
     updatedAt: Date;
+    coverUrl: string;
+    uniqueTitle: string;
 
 
     constructor(course: any) {
@@ -14,7 +16,9 @@ export class CourseResponse {
         this.description = course.description;
         this.difficultyLevel = course.difficultyLevel;
         this.price = course.price;
+        this.coverUrl = course.coverUrl;
         this.createdAt = course.createdAt;
         this.updatedAt = course.updatedAt;
+        this.uniqueTitle = course.uniqueTitle;
     }
 }

--- a/src/dropbox/dropbox.module.ts
+++ b/src/dropbox/dropbox.module.ts
@@ -4,6 +4,7 @@ import { DropboxController } from './dropbox.controller';
 
 @Module({
   providers: [DropboxService],
-  controllers: [DropboxController]
+  controllers: [DropboxController],
+  exports: [DropboxService],
 })
 export class DropboxModule {}

--- a/src/dropbox/request/get-file-path.request.ts
+++ b/src/dropbox/request/get-file-path.request.ts
@@ -1,0 +1,13 @@
+import { Transform } from "class-transformer";
+import { IsNotNullOrUndefined } from "src/validator/Is-not-null-or-undefined.decorator";
+
+export class GetFilePathRequest {
+    @IsNotNullOrUndefined()
+    @Transform(({ value }) => value.trim())
+    folderPath: string;
+
+    @IsNotNullOrUndefined()
+    @Transform(({ value }) => value.trim())
+    shareUrl: string;
+
+}


### PR DESCRIPTION
## What does this PR do?

This PR adds support for uploading a course cover image and integrates it with Dropbox.

## Why is this needed?

To allow users to upload a cover image when creating or updating a course. The image will be uploaded to Dropbox, and the shareable link will be saved in the database.

## How did you implement it?

- Added two validation pipes for image uploads:
  - `OptionalImageValidationPipe` for optional images (used in course update).
  - `RequiredImageValidationPipe` for required images (used in course creation).
- Integrated Dropbox to handle:
  - Uploading cover images to a specific folder.
  - Generating direct access links.
  - Deleting old images if a course is updated.
- Updated the course entity to include:
  - `coverUrl` for storing the image link.
  - `uniqueTitle` generated with `slugify` to make titles unique and clean.

This makes course creation and updates more complete by supporting image uploads with proper validation and external storage.
